### PR TITLE
Fix handling path prefix

### DIFF
--- a/lib/rack/ip_address_restriction.rb
+++ b/lib/rack/ip_address_restriction.rb
@@ -28,7 +28,7 @@ module Rack
       mapping = config.map do |location, ip_masks|
         host, path = parse_location(location)
         raise ArgumentError, 'paths need to start with /' if path[0] != '/'
-        path_prefix = Pathname.new(path).cleanpath.to_s
+        path_prefix = Pathname.new(path).cleanpath.to_s.chomp('/')
 
         ip_masks = ip_masks.map { |addr| addr.is_a?(IPAddr) ? addr : IPAddr.new(addr) }
 

--- a/lib/rack/ip_address_restriction/version.rb
+++ b/lib/rack/ip_address_restriction/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class IpAddressRestriction
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/rack/shared_examples_for_rack_access.rb
+++ b/spec/rack/shared_examples_for_rack_access.rb
@@ -58,6 +58,7 @@ shared_examples_for 'Rack::Access' do
 
     context 'access to "/a" from 127.0.0.1' do
       let(:remote_addr) { '127.0.0.1' }
+      let(:path) { '/a' }
 
       it_behaves_like 'denied'
     end


### PR DESCRIPTION
If `"/" => %w(192.168.1.10)`:

It should deny access when access to `/a` from `192.168.1.11`.
